### PR TITLE
Implement suite of tests against the REST API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -26,7 +25,7 @@ dependencies {
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.assertj:assertj-core:3.9.1")
+    testImplementation("com.natpryce:hamkrest:1.7.0.0")
 }
 
 group = "uk.co.autotrader"
@@ -35,6 +34,10 @@ version = "0.0.1-SNAPSHOT"
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.natpryce:hamkrest:1.7.0.0")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
 }
 
 group = "uk.co.autotrader"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("javax.validation:validation-api:2.0.1.Final")
     implementation("org.apache.commons:commons-lang3:3.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,18 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.61"
-    id("org.springframework.boot") version "2.2.4.RELEASE"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.3.61"
+    id("org.springframework.boot") version "2.2.5.RELEASE"
     id("io.spring.dependency-management") version "1.0.9.RELEASE"
+    kotlin("jvm") version "1.3.61"
+    kotlin("plugin.spring") version "1.3.61"
+}
+
+group = "uk.co.autotrader"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {
@@ -15,7 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.apache.commons:commons-lang3:3.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
@@ -28,21 +35,13 @@ dependencies {
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
 }
 
-group = "uk.co.autotrader"
-version = "0.0.1-SNAPSHOT"
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile>().configureEach {
+tasks.withType<KotlinCompile>() {
     kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
-

--- a/src/main/kotlin/uk/co/autotrader/application/Application.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/Application.kt
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct
 
 @SpringBootApplication
 class Application
+
 @Autowired
 constructor(private val failureSimulator: FailureSimulator) {
     @PostConstruct

--- a/src/main/kotlin/uk/co/autotrader/application/Application.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/Application.kt
@@ -1,8 +1,8 @@
 package uk.co.autotrader.application
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
 import javax.annotation.PostConstruct
 
 @SpringBootApplication
@@ -18,5 +18,5 @@ constructor(private val failureSimulator: FailureSimulator) {
 }
 
 fun main(args: Array<String>) {
-    SpringApplication.run(Application::class.java, *args)
+    runApplication<Application>(*args)
 }

--- a/src/main/kotlin/uk/co/autotrader/application/EchoStatusController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/EchoStatusController.kt
@@ -1,6 +1,7 @@
 package uk.co.autotrader.application
 
 import io.micrometer.core.annotation.Timed
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -13,12 +14,15 @@ import org.springframework.web.bind.annotation.RestController
 @Timed
 class EchoStatusController {
 
+    private val LOG = LoggerFactory.getLogger(EchoStatusController::class.java)
+
     @GetMapping("/{status}")
     fun echoStatus(@PathVariable status: String): ResponseEntity<Any> {
         val httpStatus = try {
             HttpStatus.valueOf(status.toInt())
-        } catch (e: Exception) {
-            return ResponseEntity.badRequest().body(e.message)
+        } catch (illegalArgumentException: IllegalArgumentException) {
+            LOG.error("Failed to parse status: $status", illegalArgumentException)
+            return ResponseEntity.badRequest().body("Failed to parse provided HTTP status code: $status")
         }
 
         return ResponseEntity(httpStatus)

--- a/src/main/kotlin/uk/co/autotrader/application/EchoStatusController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/EchoStatusController.kt
@@ -1,24 +1,27 @@
 package uk.co.autotrader.application
 
 import io.micrometer.core.annotation.Timed
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.ResponseEntity
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/echostatus")
 @Timed
-class EchoStatusController
-@Autowired
-constructor() {
+class EchoStatusController {
 
     @GetMapping("/{status}")
     fun echoStatus(@PathVariable status: String): ResponseEntity<Any> {
-        return ResponseEntity(HttpStatus.resolve(status.toInt()))
+        val httpStatus = try {
+            HttpStatus.valueOf(status.toInt())
+        } catch (e: Exception) {
+            return ResponseEntity.badRequest().body(e.message)
+        }
+
+        return ResponseEntity(httpStatus)
     }
 
 }

--- a/src/main/kotlin/uk/co/autotrader/application/Failures.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/Failures.kt
@@ -13,11 +13,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
-import java.time.Instant
 import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatter.ISO_INSTANT
 import java.util.*
 import java.util.stream.Collectors
 import java.util.stream.IntStream
@@ -26,7 +23,6 @@ import kotlin.concurrent.timer
 import kotlin.system.exitProcess
 
 interface Failure {
-
     fun fail(params: Map<String, String> = emptyMap())
 }
 

--- a/src/main/kotlin/uk/co/autotrader/application/Failures.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/Failures.kt
@@ -2,7 +2,6 @@ package uk.co.autotrader.application
 
 import org.apache.commons.lang3.RandomUtils
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import uk.co.autotrader.application.WriteRandomBytesToFile.writeRandomBytesToFile
 import java.io.*
@@ -29,12 +28,10 @@ interface Failure {
 private val LOG = LoggerFactory.getLogger(FailureSimulator::class.java)
 
 @Component
-class FailureSimulator
+class FailureSimulator(private val failures: Map<String, Failure>) {
 
-@Autowired
-constructor(private val failures: Map<String, Failure>) {
     fun run(type: String?, params: Map<String, String> = emptyMap()): Boolean {
-        if (type != null) {
+        if (!type.isNullOrBlank()) {
             val failure: Failure? = failures[type]
             return if (failure == null) {
                 LOG.error("Unknown failure '{}'", type)

--- a/src/main/kotlin/uk/co/autotrader/application/RootController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/RootController.kt
@@ -1,6 +1,5 @@
 package uk.co.autotrader.application
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -8,9 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/")
-class RootController
-@Autowired
-constructor() {
+class RootController {
 
     @GetMapping
     fun hello(): ResponseEntity<String> {

--- a/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/simulate")
 @Timed
-class SimulationController(private var failureSimulator: FailureSimulator) {
+class SimulationController(private val failureSimulator: FailureSimulator) {
 
     @PostMapping("/{failureName}")
     fun simulateFailure(@PathVariable failureName: String, @RequestParam params: Map<String, String>): ResponseEntity<String> {

--- a/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
@@ -1,20 +1,16 @@
 package uk.co.autotrader.application
 
 import io.micrometer.core.annotation.Timed
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/simulate")
 @Timed
-class SimulationController
-
-@Autowired
-constructor(private var failureSimulator: FailureSimulator) {
+class SimulationController(private var failureSimulator: FailureSimulator) {
 
     @PostMapping("/{failureName}")
-    fun triggerFailure(@PathVariable failureName: String, @RequestParam params: Map<String, String>): ResponseEntity<String> {
+    fun simulateFailure(@PathVariable failureName: String, @RequestParam params: Map<String, String>): ResponseEntity<String> {
 
         return if (failureSimulator.run(failureName, params))
             ResponseEntity.ok().build()

--- a/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
+++ b/src/main/kotlin/uk/co/autotrader/application/SimulationController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/simulate")
 @Timed
 class SimulationController
+
 @Autowired
 constructor(private var failureSimulator: FailureSimulator) {
 

--- a/src/test/kotlin/uk/co/autotrader/application/EchoStatusControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/EchoStatusControllerShould.kt
@@ -1,0 +1,5 @@
+package uk.co.autotrader.application
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class EchoStatusControllerShould

--- a/src/test/kotlin/uk/co/autotrader/application/EchoStatusControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/EchoStatusControllerShould.kt
@@ -1,5 +1,25 @@
 package uk.co.autotrader.application
 
-import org.junit.jupiter.api.Assertions.*
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
 
-internal class EchoStatusControllerShould
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class EchoStatusControllerShould(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun `respond with valid status code`() {
+        val response = restTemplate.getForEntity("/echostatus/418", String::class.java)
+        assertThat(response.statusCode, equalTo(HttpStatus.I_AM_A_TEAPOT))
+    }
+
+    @Test
+    fun `respond with bad request for invalid status code`() {
+        val response = restTemplate.getForEntity("/echostatus/999", String::class.java)
+        assertThat(response.statusCode, equalTo(HttpStatus.BAD_REQUEST))
+    }
+}

--- a/src/test/kotlin/uk/co/autotrader/application/RootControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/RootControllerShould.kt
@@ -1,0 +1,21 @@
+package uk.co.autotrader.application
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.getForEntity
+import org.springframework.http.HttpStatus
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RootControllerShould(@Autowired val restTemplate: TestRestTemplate) {
+    @Test
+    fun `return a welcome message`() {
+        val entity = restTemplate.getForEntity<String>("/")
+        assertThat(entity.statusCode, equalTo(HttpStatus.OK))
+        assertThat(entity.body, equalTo("This kraken is running and ready to cause some chaos."))
+    }
+}
+

--- a/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
@@ -33,12 +33,6 @@ class SimulationControllerShould(@Autowired val restTemplate: TestRestTemplate) 
     }
 
     @Test
-    fun `echo status code`() {
-        val response = restTemplate.getForEntity("/echostatus/418", String::class.java)
-        assertThat(response.statusCode, equalTo(HttpStatus.I_AM_A_TEAPOT))
-    }
-
-    @Test
     fun `delegate to specific failure type`() {
         val response = restTemplate.postForEntity("/simulate/custom", emptyRequestBody, String::class.java)
         assertThat(response.statusCode, equalTo(HttpStatus.OK))

--- a/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
@@ -1,0 +1,21 @@
+package uk.co.autotrader.application
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SimulationControllerShould(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun `return bad request for unknown failure`() {
+        val entity = restTemplate.postForEntity("/simulate/unknown", null, String::class.java)
+        assertThat(entity.statusCode, equalTo(HttpStatus.BAD_REQUEST))
+        assertThat(entity.body, equalTo("Unrecognised failure. Failed at failing this service."))
+    }
+
+}

--- a/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
@@ -2,17 +2,22 @@ package uk.co.autotrader.application
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyMap
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.http.HttpStatus
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class SimulationControllerShould(@Autowired val restTemplate: TestRestTemplate) {
+const val emptyRequestBody = ""
 
-    private val emptyRequestBody = ""
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SimulationControllerWithRealFailureSimulatorShould(@Autowired val restTemplate: TestRestTemplate) {
 
     @Test
     fun `return bad request for unknown failure`() {
@@ -29,5 +34,22 @@ class SimulationControllerShould(@Autowired val restTemplate: TestRestTemplate) 
         val serviceHealth = restTemplate.getForEntity<String>("/actuator/health")
         assertThat(serviceHealth.statusCode, equalTo(HttpStatus.SERVICE_UNAVAILABLE))
     }
+}
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SimulationControllerWithFakeFailureSimulatorShould(@Autowired val restTemplate: TestRestTemplate) {
+
+    @MockBean
+    private lateinit var failureSimulator: FailureSimulator
+
+    @Test
+    fun `simulate killapp failure`() {
+        whenever(failureSimulator.run(eq("killapp"), anyMap())).thenReturn(true)
+
+        val response = restTemplate.postForEntity("/simulate/killapp", emptyRequestBody, String::class.java)
+        assertThat(response.statusCode, equalTo(HttpStatus.OK))
+
+        verify(failureSimulator).run(eq("killapp"), anyMap())
+
+    }
 }

--- a/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
+++ b/src/test/kotlin/uk/co/autotrader/application/SimulationControllerShould.kt
@@ -6,16 +6,28 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.getForEntity
 import org.springframework.http.HttpStatus
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SimulationControllerShould(@Autowired val restTemplate: TestRestTemplate) {
 
+    private val emptyRequestBody = ""
+
     @Test
     fun `return bad request for unknown failure`() {
-        val entity = restTemplate.postForEntity("/simulate/unknown", null, String::class.java)
-        assertThat(entity.statusCode, equalTo(HttpStatus.BAD_REQUEST))
-        assertThat(entity.body, equalTo("Unrecognised failure. Failed at failing this service."))
+        val response = restTemplate.postForEntity("/simulate/unknown", emptyRequestBody, String::class.java)
+        assertThat(response.statusCode, equalTo(HttpStatus.BAD_REQUEST))
+        assertThat(response.body, equalTo("Unrecognised failure. Failed at failing this service."))
+    }
+
+    @Test
+    fun `toggle health to service unavailable`() {
+        val response = restTemplate.postForEntity("/simulate/toggle-service-health", emptyRequestBody, String::class.java)
+        assertThat(response.statusCode, equalTo(HttpStatus.OK))
+
+        val serviceHealth = restTemplate.getForEntity<String>("/actuator/health")
+        assertThat(serviceHealth.statusCode, equalTo(HttpStatus.SERVICE_UNAVAILABLE))
     }
 
 }


### PR DESCRIPTION
This PR provides test coverage of the exposed REST API for the `SimulationController`. 

It uses a custom failure type due to it not being possible to test real failures within the same JVM process. The plan is to test real failure using a different strategy that build the full JAR and interacts with it externally.

Contributes to #5 